### PR TITLE
[REFACTOR] TVDeatilViewCon관련 뷰컨/뷰의 상속관계로 반복되는 함수호출 부분 삭제

### DIFF
--- a/MediaProject.xcodeproj/project.pbxproj
+++ b/MediaProject.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		8B5A3F992B6CF0FA00B7DD22 /* TVDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5A3F982B6CF0FA00B7DD22 /* TVDetailTableViewCell.swift */; };
 		8B5A3F9B2B6D3F3D00B7DD22 /* TVDetailCastingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5A3F9A2B6D3F3D00B7DD22 /* TVDetailCastingTableViewCell.swift */; };
 		8B5A3F9D2B6E001000B7DD22 /* TVDetailCastingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5A3F9C2B6E001000B7DD22 /* TVDetailCastingCollectionViewCell.swift */; };
+		8B5A3FA02B6E238A00B7DD22 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5A3F9F2B6E238A00B7DD22 /* BaseViewController.swift */; };
+		8B5A3FA22B6E23A600B7DD22 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5A3FA12B6E23A600B7DD22 /* Protocol.swift */; };
+		8B5A3FA42B6E842C00B7DD22 /* BaseUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5A3FA32B6E842C00B7DD22 /* BaseUIView.swift */; };
+		8B5A3FA62B6E888F00B7DD22 /* TVDatailUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5A3FA52B6E888F00B7DD22 /* TVDatailUIView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,6 +68,10 @@
 		8B5A3F982B6CF0FA00B7DD22 /* TVDetailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVDetailTableViewCell.swift; sourceTree = "<group>"; };
 		8B5A3F9A2B6D3F3D00B7DD22 /* TVDetailCastingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVDetailCastingTableViewCell.swift; sourceTree = "<group>"; };
 		8B5A3F9C2B6E001000B7DD22 /* TVDetailCastingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVDetailCastingCollectionViewCell.swift; sourceTree = "<group>"; };
+		8B5A3F9F2B6E238A00B7DD22 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		8B5A3FA12B6E23A600B7DD22 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
+		8B5A3FA32B6E842C00B7DD22 /* BaseUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUIView.swift; sourceTree = "<group>"; };
+		8B5A3FA52B6E888F00B7DD22 /* TVDatailUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVDatailUIView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,7 +109,8 @@
 		8B5A3F312B68DD9700B7DD22 /* MediaProject */ = {
 			isa = PBXGroup;
 			children = (
-				8B5A3F792B6A422200B7DD22 /* TV */,
+				8B5A3F9E2B6E237500B7DD22 /* Base */,
+				8B5A3F792B6A422200B7DD22 /* TVDetail */,
 				8B5A3F612B69198A00B7DD22 /* CollectionViewCell */,
 				8B5A3F5E2B68F26800B7DD22 /* TableViewCell */,
 				8B5A3F552B68EBDC00B7DD22 /* TVGroup */,
@@ -113,6 +122,7 @@
 				8B5A3F3B2B68DD9900B7DD22 /* Assets.xcassets */,
 				8B5A3F3D2B68DD9900B7DD22 /* LaunchScreen.storyboard */,
 				8B5A3F402B68DD9900B7DD22 /* Info.plist */,
+				8B5A3FA12B6E23A600B7DD22 /* Protocol.swift */,
 			);
 			path = MediaProject;
 			sourceTree = "<group>";
@@ -158,12 +168,13 @@
 			path = CollectionViewCell;
 			sourceTree = "<group>";
 		};
-		8B5A3F792B6A422200B7DD22 /* TV */ = {
+		8B5A3F792B6A422200B7DD22 /* TVDetail */ = {
 			isa = PBXGroup;
 			children = (
 				8B5A3F7A2B6A424000B7DD22 /* TVDetailViewController.swift */,
+				8B5A3FA52B6E888F00B7DD22 /* TVDatailUIView.swift */,
 			);
-			path = TV;
+			path = TVDetail;
 			sourceTree = "<group>";
 		};
 		8B5A3F7C2B6A81A600B7DD22 /* TVDetail */ = {
@@ -183,6 +194,15 @@
 				8B5A3F9C2B6E001000B7DD22 /* TVDetailCastingCollectionViewCell.swift */,
 			);
 			path = TVDetail;
+			sourceTree = "<group>";
+		};
+		8B5A3F9E2B6E237500B7DD22 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				8B5A3F9F2B6E238A00B7DD22 /* BaseViewController.swift */,
+				8B5A3FA32B6E842C00B7DD22 /* BaseUIView.swift */,
+			);
+			path = Base;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -273,17 +293,21 @@
 				8B5A3F9B2B6D3F3D00B7DD22 /* TVDetailCastingTableViewCell.swift in Sources */,
 				8B5A3F6A2B6941A500B7DD22 /* TVPopularModel.swift in Sources */,
 				8B5A3F7E2B6A82A500B7DD22 /* TVDetailRecommendTableViewCell.swift in Sources */,
+				8B5A3FA02B6E238A00B7DD22 /* BaseViewController.swift in Sources */,
 				8B5A3F7B2B6A424000B7DD22 /* TVDetailViewController.swift in Sources */,
 				8B5A3F502B68DE5300B7DD22 /* TMDBAPIManager.swift in Sources */,
 				8B5A3F8D2B6BD1FF00B7DD22 /* TVDetailModel.swift in Sources */,
+				8B5A3FA62B6E888F00B7DD22 /* TVDatailUIView.swift in Sources */,
 				8B5A3F8F2B6BD75300B7DD22 /* TVModels.swift in Sources */,
 				8B5A3F372B68DD9700B7DD22 /* ViewController.swift in Sources */,
 				8B5A3F992B6CF0FA00B7DD22 /* TVDetailTableViewCell.swift in Sources */,
 				8B5A3F832B6A8C7700B7DD22 /* TVRecommendCollectionViewCell.swift in Sources */,
 				8B5A3F5D2B68F12900B7DD22 /* TVTrendModel.swift in Sources */,
+				8B5A3FA42B6E842C00B7DD22 /* BaseUIView.swift in Sources */,
 				8B5A3F912B6BD80F00B7DD22 /* TVCastModel.swift in Sources */,
 				8B5A3F332B68DD9700B7DD22 /* AppDelegate.swift in Sources */,
 				8B5A3F602B68F27E00B7DD22 /* SearchTableViewCell.swift in Sources */,
+				8B5A3FA22B6E23A600B7DD22 /* Protocol.swift in Sources */,
 				8B5A3F5B2B68F05A00B7DD22 /* APIKey.swift in Sources */,
 				8B5A3F352B68DD9700B7DD22 /* SceneDelegate.swift in Sources */,
 				8B5A3F632B69199F00B7DD22 /* SearchCollectionViewCell.swift in Sources */,

--- a/MediaProject/Base/BaseUIView.swift
+++ b/MediaProject/Base/BaseUIView.swift
@@ -1,0 +1,37 @@
+//
+//  BaseUIView.swift
+//  MediaProject
+//
+//  Created by 남현정 on 2024/02/03.
+//
+
+import UIKit
+
+class BaseUIView: UIView, Configure {
+    // Configure프로토콜을 따라서 뷰 구성에 필수적인 부분 구현
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .red // ?
+        configureHierarchy()
+        configureConstraints()
+        configureView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureHierarchy() {
+        <#code#>
+    }
+    
+    func configureConstraints() {
+        <#code#>
+    }
+    
+    func configureView() {
+        <#code#>
+    }
+    
+}

--- a/MediaProject/Base/BaseUIView.swift
+++ b/MediaProject/Base/BaseUIView.swift
@@ -12,7 +12,7 @@ class BaseUIView: UIView, Configure {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.backgroundColor = .red // ?
+        self.backgroundColor = .black // ?
         configureHierarchy()
         configureConstraints()
         configureView()
@@ -23,15 +23,15 @@ class BaseUIView: UIView, Configure {
     }
     
     func configureHierarchy() {
-        <#code#>
+        
     }
     
     func configureConstraints() {
-        <#code#>
+        
     }
     
     func configureView() {
-        <#code#>
     }
+    
     
 }

--- a/MediaProject/Base/BaseViewController.swift
+++ b/MediaProject/Base/BaseViewController.swift
@@ -1,0 +1,30 @@
+//
+//  BaseViewController.swift
+//  MediaProject
+//
+//  Created by 남현정 on 2024/02/03.
+//
+
+import UIKit
+
+class BaseViewController: UIViewController, Configure {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureHierarchy()
+        configureConstraints()
+        configureView()
+    }
+    
+    func configureHierarchy() {
+        
+    }
+    
+    func configureConstraints() {
+        
+    }
+    
+    func configureView() {
+       
+    }
+}

--- a/MediaProject/Protocol.swift
+++ b/MediaProject/Protocol.swift
@@ -1,0 +1,15 @@
+//
+//  Protocol.swift
+//  MediaProject
+//
+//  Created by 남현정 on 2024/02/03.
+//
+
+import Foundation
+
+//  ViewCon이나 여러 뷰들에 공통적으로 구성되는 함수들 > 프로토콜
+protocol Configure {
+    func configureHierarchy()
+    func configureConstraints()
+    func configureView()
+}

--- a/MediaProject/TVDetail/TVDatailUIView.swift
+++ b/MediaProject/TVDetail/TVDatailUIView.swift
@@ -1,0 +1,40 @@
+//
+//  TVDatailUIView.swift
+//  MediaProject
+//
+//  Created by 남현정 on 2024/02/03.
+//
+
+import UIKit
+
+class TVDatailUIView: BaseUIView {
+
+    // init구문은 BaseUIView에서 실행될 것이기 때문에 쓰지 않아도 된다.'
+    
+    lazy var tvTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.backgroundColor = .black
+        // 추천 테이블뷰셀
+        tableView.register(TVDetailRecommendTableViewCell.self, forCellReuseIdentifier: "TVDetailRecommendTableViewCell")
+        // 드라마 디테일 테이블뷰셀
+        tableView.register(TVDetailTableViewCell.self, forCellReuseIdentifier: "TVDetailTableViewCell")
+        // 드라마 캐스팅 정보 테이블뷰셀
+        tableView.register(TVDetailCastingTableViewCell.self, forCellReuseIdentifier: "TVDetailCastingTableViewCell")
+        
+//        tableView.rowHeight = 280
+        tableView.rowHeight = UITableView.automaticDimension // 유동적으로 높이 늘어나도록
+        
+        return tableView
+    }()
+    
+    override func configureHierarchy() {
+        self.addSubview(tvTableView)
+    }
+    
+    override func configureConstraints() {
+        tvTableView.snp.makeConstraints { make in
+            make.edges.equalTo(safeAreaLayoutGuide)
+            
+        }
+    }
+}

--- a/MediaProject/TVDetail/TVDetailViewController.swift
+++ b/MediaProject/TVDetail/TVDetailViewController.swift
@@ -9,25 +9,9 @@ import UIKit
 import SnapKit
 import Kingfisher
 
-class TVDetailViewController: UIViewController {
+class TVDetailViewController: BaseViewController {
     
-    lazy var tvTableView: UITableView = {
-        let tableView = UITableView()
-        tableView.backgroundColor = .black
-        // 추천 테이블뷰셀
-        tableView.register(TVDetailRecommendTableViewCell.self, forCellReuseIdentifier: "TVDetailRecommendTableViewCell")
-        // 드라마 디테일 테이블뷰셀
-        tableView.register(TVDetailTableViewCell.self, forCellReuseIdentifier: "TVDetailTableViewCell")
-        // 드라마 캐스팅 정보 테이블뷰셀
-        tableView.register(TVDetailCastingTableViewCell.self, forCellReuseIdentifier: "TVDetailCastingTableViewCell")
-        
-        tableView.delegate = self
-        tableView.dataSource = self
-//        tableView.rowHeight = 280
-        tableView.rowHeight = UITableView.automaticDimension // 유동적으로 높이 늘어나도록
-        
-        return tableView
-    }()
+    let mainView = TVDatailUIView()
 
     let list = ["TV정보", "비슷한 콘텐츠 추천", "캐스팅 정보"]
     
@@ -39,14 +23,16 @@ class TVDetailViewController: UIViewController {
     /// 드라마 캐스팅 정보 리스트
     var castingList: [TVCast] = []
     
+    override func loadView() {
+        self.view = mainView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .black
-        
-        configureHierarchy()
-        configureConstraints()
-        
+        mainView.tvTableView.delegate = self
+        mainView.tvTableView.dataSource = self
+        // 네트워크 통신
         fetchTVData()
     }
     
@@ -75,24 +61,10 @@ class TVDetailViewController: UIViewController {
         
         group.notify(queue: .main) {
 
-            self.tvTableView.reloadData()
+            self.mainView.tvTableView.reloadData()
         }
     }
 }
-
-extension TVDetailViewController {
-    func configureHierarchy() {
-        view.addSubview(tvTableView)
-    }
-    
-    func configureConstraints() {
-        tvTableView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
-            
-        }
-    }
-}
-
 
 extension TVDetailViewController: UITableViewDelegate, UITableViewDataSource {
  

--- a/MediaProject/TVGroup/TVGroupViewController.swift
+++ b/MediaProject/TVGroup/TVGroupViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Kingfisher
 
-class TVGroupViewController: UIViewController {
+class TVGroupViewController: BaseViewController {
     // 섹션에 해보기
     let tableView = UITableView()
     /// 섹션에 나올 타이틀
@@ -21,12 +21,7 @@ class TVGroupViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        configureHierarchy()
-        configureConstraints()
-        configureView()
-        
         configureTableView()
-        
         fetchTMDB()
     }
     
@@ -48,25 +43,23 @@ class TVGroupViewController: UIViewController {
         }
     }
     
-    
-}
-
-extension TVGroupViewController {
-    func configureHierarchy() {
+    // BaseViewController
+    override func configureHierarchy() {
         view.addSubview(tableView)
     }
     
-    func configureView() {
+    override func configureView() {
         tableView.backgroundColor = .red
         
 
     }
     
-    func configureConstraints() {
+    override func configureConstraints() {
         tableView.snp.makeConstraints { make in
             make.edges.equalTo(view.safeAreaLayoutGuide)
         }
     }
+    
 }
 
 extension TVGroupViewController: UITableViewDelegate, UITableViewDataSource {


### PR DESCRIPTION
## 🚀관련 이슈
- close #7 
- 
## 💎작업 내용
- BaseViewController을  TVDetailViewCon이 상속하도록
- TVDetailUIView파일을 따로 만들어서 UI부분 담당
- BaseUIView를 TVDetailUIView가 상속하도록

## ⭐️참고 사항
![스크린샷 2024-02-04 오전 11 12 36](https://github.com/nhyeonjeong/MediaProject/assets/102401977/31524530-0bf5-4efd-94a2-3ae4977e760e)
![스크린샷 2024-02-04 오전 11 13 06](https://github.com/nhyeonjeong/MediaProject/assets/102401977/92c5ff05-5e51-45ad-960a-44794ba1824d)

BaseUIView에 있던 init을 override해준 뒤 super.init(frame: frame)을 호출해주지 않았을 때
